### PR TITLE
Move submodules from ssh/git to https rtfd.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ on:
 jobs:
   functional-tests:
     uses: ./.github/workflows/functional.yml
-    secrets: inherit
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     with:
       api_version: dev
       worker_version: dev

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
-[submodule "repository-service-tuf-api"]
-	path = repository-service-tuf-api
-	url = git@github.com:vmware/repository-service-tuf-api.git
 [submodule "repository-service-tuf-worker"]
 	path = repository-service-tuf-worker
-	url = git@github.com:vmware/repository-service-tuf-worker.git
+	url = https://github.com/vmware/repository-service-tuf-worker.git
+[submodule "repository-service-tuf-api"]
+	path = repository-service-tuf-api
+	url = https://github.com/vmware/repository-service-tuf-api.git
 [submodule "repository-service-tuf-cli"]
 	path = repository-service-tuf-cli
-	url = git@github.com:vmware/repository-service-tuf-cli.git
+	url = https://github.com/vmware/repository-service-tuf-cli.git


### PR DESCRIPTION
Moving submodules from ssh/git to https.

The readthedocs.org doesn't support submodules as ssh/git

https://readthedocs.org/projects/tuf-repository-service/

Also, trying to pass the token to functional.yml -- will not be a problem when the GitHub Packages Registry for RSTUF becomes public.

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>