### PR TITLE
Add .readthedocs.yaml file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,24 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
+  # jobs:
+  #   post_system_dependencies:
+  #     - make docs
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+    - requirements: requirements.txt


### PR DESCRIPTION
As RSTUF requires a specific version of python, we will control it using the .readthedocs.yml file.
Also, we will require `post_system_dependencies` (`make docs`) in the future -- the reason why it is commented.

Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>