### PR TITLE
build: disable dependabot for python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,3 @@ updates:
       prefix: "build"
       include: "scope"
     open-pull-requests-limit: 10
-  # Monitor Python dependencies
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "10:00"
-    commit-message:
-      prefix: "build"
-      include: "scope"
-    open-pull-requests-limit: 10


### PR DESCRIPTION
The following PR disables Dependabot alerts for Python.

See #82 

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>