### PR TITLE
fix: condition to correct get vX.Y.Z

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Install Python Dependencies
         run: |
-          pip install pipenv
+          pip install pipenv dynaconf[ini]
           pip install -r requirements.txt
 
       - name: Install the RSTUF Command Line Interface (dev)
@@ -114,8 +114,8 @@ jobs:
           pip install .
           cd ..
 
-      - name: Install the RSTUF Command Line Interface (${{ inputs.cli_version }})
-        if: ${{ inputs.cli_version != 'dev' }}
+      - name: Install the RSTUF Command Line Interface (vX.Y.Z)
+        if: ${{ startsWith(inputs.cli_version, 'v') }}
         # replace the run below after repository-service-tuf is available in
         # pypi.org
         # run: |
@@ -147,6 +147,7 @@ jobs:
                 break; \
               fi; \
             done
+            rstuf -c rstuf.ini admin login -s http://localhost -u admin -p test-secret -e 1
             make functional-tests
 
       - name: Check Tests Lint and Dependencies

--- a/tests/functional/bootstrap/test_bootstrap.py
+++ b/tests/functional/bootstrap/test_bootstrap.py
@@ -13,8 +13,8 @@ def test_bootstrap_using_rstuf_command_line_interface_cli():
 
 @given("the repository-service-tuf (rstuf) is installed")
 def the_tufrepositoryservice_rstufcli_is_installed(rstuf_cli):
-    rc, _ = rstuf_cli("-h")
-    assert rc == 0
+    rc, output = rstuf_cli("-h")
+    assert rc == 0, output
 
 
 @given("the admin login to RSTUF using rstuf", target_fixture="login")
@@ -29,7 +29,7 @@ def the_administrator_login_to_rstuf(get_admin_pwd, rstuf_cli):
 @given("the admin is logged in")
 def the_admin_is_logged(login):
     rc, output = login
-    assert rc == 0
+    assert rc == 0, output
     assert "Login successfuly." in output or "Already logged to " in output
 
 
@@ -38,7 +38,6 @@ def the_admin_is_logged(login):
 )
 def the_administrator_uses_rstufcli_bootstrap(rstuf_cli):
     rc, output = rstuf_cli("admin ceremony -b -u -f tests/data/payload.json")
-    breakpoint()
     return rc, output
 
 
@@ -47,9 +46,8 @@ def the_administrator_uses_rstufcli_bootstrap(rstuf_cli):
     '"Already has metadata"'
 )
 def the_admin_gets(bootstrap):
-    rc, output = bootstrap
+    _, output = bootstrap
 
-    assert rc == 0
     assert "SUCCESS" or "System already has a Metadata." in output
     assert (
         "Bootstrap finished." in output
@@ -78,5 +76,5 @@ def the_administrator_uses_rstufcli_bootstrap_invalid_payload(rstuf_cli):
 @then('the admin gets "Error 422"')
 def then_admin_gets_error_422(invalid_payload):
     rc, output = invalid_payload
-    assert rc == 1
+    assert rc == 1, output
     assert "422" in output

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -15,7 +15,7 @@ def rstuf_cli():
     def _run_rstuf_cli(params: List):
 
         result = subprocess.run(
-            ["rstuf"] + params.split(), capture_output=True
+            ["rstuf", "-c", "rstuf.ini"] + params.split(), capture_output=True
         )
 
         return result.returncode, result.stdout.decode("utf-8")


### PR DESCRIPTION
The current logic fails because the if `cli_version` is different of 'dev' it will try to install twice the 'latest' and there is no branch latest.

It looks for some specific tag/branch when it starts with 'v'

- Dynaconf[ini] still needed to be installed explicity (https://github.com/vmware/repository-service-tuf-cli/issues/119)

- Made the assert error return more explict in case for rc code tests

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>