### PR TITLE
chore: fix rendering for github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,7 @@
 name: 🪲 Bug
 description: File a bug report
 title: "Bug: "
-labels: ["bug"]
+labels: ["bug", "needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -14,10 +14,11 @@ body:
       description: Please provide a detailed description of your idea.
     validations:
       required: true
- - type: dropdown
+  - type: dropdown
     id: services
     attributes:
-      label: Please select which services do you think will be impacted.
+      label: Services it relates to
+      description: Please select which services do you think will be impacted.
       multiple: true
       options:
         - repository-service-for-tuf

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -14,10 +14,11 @@ body:
       description: Please provide a detailed description of the feature.
     validations:
       required: true
- - type: dropdown
+  - type: dropdown
     id: services
     attributes:
-      label: Please select which services do you think will be impacted.
+      label: Services it relates to
+      description: Please select which services do you think will be impacted.
       multiple: true
       options:
         - repository-service-for-tuf


### PR DESCRIPTION
Fixes the rendering issues for some of the GitHub templates. 

Also adds the `needs-triage` label to the Bug template.

Closes #89 

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>