### PR TITLE
Simplify functional

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -35,7 +35,9 @@ on:
         default: "latest"
         type: string
         required: False
-
+env:
+  MAKE_FT_TARGET: functional-tests
+  
 jobs:
   functional:
     runs-on: ubuntu-latest
@@ -78,11 +80,22 @@ jobs:
           RSTUF_REDIS_SERVER: redis://redis
           SECRETS_RSTUF_TOKEN_KEY: test-token-key
           SECRETS_RSTUF_ADMIN_PASSWORD: test-secret
-
     steps:
       - name: Checkout release tag
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+    
+      - name: Checkout release tag if not umbrella
+        if: ${{ github.GITHUB_REPOSITORY != 'vmware/repository-service-tuf' }} 
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+        with:
+           repository: vmware/repository-service-tuf
+           path: rstuf-umbrella
+           ref: main
 
+      - name: Update make functional tests target variable
+        if: ${{ github.GITHUB_REPOSITORY != 'vmware/repository-service-tuf' }} 
+        run: echo "MAKE_FT_TARGET=-C rstuf-umbrella/ functional-tests" >> $GITHUB_ENV
+        
       - name: Set up Python
         uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
         with:
@@ -95,17 +108,10 @@ jobs:
 
       - name: Checkout the Repository Service for TUF CLI
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-        if: ${{ inputs.cli_version == 'dev' }}
         with:
           repository: vmware/repository-service-tuf-cli
           path: rstuf-cli
           ref: main
-          
-      - name: Checkout the Repository Service for TUF CLI
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-        with:
-          repository: vmware/repository-service-tuf-cli
-          path: rstuf-cli
        
       - name: Install the RSTUF Command Line Interface (dev)
         if: ${{ inputs.cli_version == 'dev' }}
@@ -163,4 +169,4 @@ jobs:
               fi; \
             done
             rstuf -c rstuf.ini admin login -s http://localhost -u admin -p test-secret -e 1
-            make functional-tests
+            make ${{ env.MAKE_FT_TARGET }}

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
     
       - name: Checkout release tag if not umbrella
-        if: github.repository != 'vmware/repository-service-tuf
+        if: github.repository != 'vmware/repository-service-tuf'
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
         with:
            repository: vmware/repository-service-tuf
@@ -93,7 +93,7 @@ jobs:
            ref: main
 
       - name: Update make functional tests target variable
-        if: github.repository != 'vmware/repository-service-tuf 
+        if: github.repository != 'vmware/repository-service-tuf'
         run: |
           echo "MAKE_FT_TARGET=-C rstuf-umbrella/ functional-tests" >> $GITHUB_ENV
           pip install -r rstuf-umbrella/requirements.txt

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -93,17 +93,28 @@ jobs:
           pip install pipenv dynaconf[ini]
           pip install -r requirements.txt
 
+      - name: Checkout the Repository Service for TUF CLI
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+        if: ${{ inputs.cli_version == 'dev' }}
+        with:
+          repository: vmware/repository-service-tuf-cli
+          path: rstuf-cli
+          ref: main
+          
+      - name: Checkout the Repository Service for TUF CLI
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+        with:
+          repository: vmware/repository-service-tuf-cli
+          path: rstuf-cli
+       
       - name: Install the RSTUF Command Line Interface (dev)
         if: ${{ inputs.cli_version == 'dev' }}
-        run: |
-          git clone git@github.com:vmware/repository-service-tuf-cli.git rstuf-cli
-          cd rstuf-cli
-          git fetch
-          git pull
-          git checkout main          
-          cd ..
-          pip install rstuf-cli/
-
+        # replace the run below after repository-service-tuf is available in
+        # pypi.org
+        # run: |
+        #   pip install "dynaconf[ini]" repository-service-tuf
+        run: pip install rstuf-cli/    
+          
       - name: Install the RSTUF Command Line Interface (latest)
         if: ${{ inputs.cli_version == 'latest' }}
         # replace the run below after repository-service-tuf is available in
@@ -111,7 +122,6 @@ jobs:
         # run: |
         #   pip install "dynaconf[ini]" repository-service-tuf
         run: |
-          git clone git@github.com:vmware/repository-service-tuf-cli.git rstuf-cli
           cd rstuf-cli
           git fetch
           git pull
@@ -126,7 +136,6 @@ jobs:
         # run: |
         #   pip install "dynaconf[ini]" repository-service-tuf==${{ inputs.cli_version }}
         run: |
-          git clone git@github.com:vmware/repository-service-tuf-cli.git rstuf-cli
           cd rstuf-cli
           git fetch
           git pull

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -37,6 +37,7 @@ on:
         required: False
 env:
   MAKE_FT_TARGET: functional-tests
+  REQUIREMENTS_PATH: requirements.txt
   
 jobs:
   functional:
@@ -92,11 +93,11 @@ jobs:
            path: rstuf-umbrella
            ref: main
 
-      - name: Update make functional tests target variable
+      - name: Update environment variables
         if: github.repository != 'vmware/repository-service-tuf'
         run: |
           echo "MAKE_FT_TARGET=-C rstuf-umbrella/ functional-tests" >> $GITHUB_ENV
-          pip install -r rstuf-umbrella/requirements.txt
+          echo "REQUIREMENTS_PATH=rstuf-umbrella/requirements.txt" >> $GITHUB_ENV
         
       - name: Set up Python
         uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
@@ -106,7 +107,7 @@ jobs:
       - name: Install Python Dependencies
         run: |
           pip install pipenv dynaconf[ini]
-          pip install -r requirements.txt
+          pip install -r ${{ env.REQUIREMENTS_PATH }}
 
       - name: Checkout the Repository Service for TUF CLI
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
     
       - name: Checkout release tag if not umbrella
-        if: ${{ github.GITHUB_REPOSITORY != 'vmware/repository-service-tuf' }} 
+        if: github.repository != 'vmware/repository-service-tuf
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
         with:
            repository: vmware/repository-service-tuf
@@ -93,7 +93,7 @@ jobs:
            ref: main
 
       - name: Update make functional tests target variable
-        if: ${{ github.GITHUB_REPOSITORY != 'vmware/repository-service-tuf' }} 
+        if: github.repository != 'vmware/repository-service-tuf 
         run: |
           echo "MAKE_FT_TARGET=-C rstuf-umbrella/ functional-tests" >> $GITHUB_ENV
           pip install -r rstuf-umbrella/requirements.txt

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -94,7 +94,9 @@ jobs:
 
       - name: Update make functional tests target variable
         if: ${{ github.GITHUB_REPOSITORY != 'vmware/repository-service-tuf' }} 
-        run: echo "MAKE_FT_TARGET=-C rstuf-umbrella/ functional-tests" >> $GITHUB_ENV
+        run: |
+          echo "MAKE_FT_TARGET=-C rstuf-umbrella/ functional-tests" >> $GITHUB_ENV
+          pip install -r rstuf-umbrella/requirements.txt
         
       - name: Set up Python
         uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -96,9 +96,13 @@ jobs:
       - name: Install the RSTUF Command Line Interface (dev)
         if: ${{ inputs.cli_version == 'dev' }}
         run: |
-          git submodule update --init repository-service-tuf-cli
-          git submodule foreach git pull origin main
-          pip install repository-service-tuf-cli/
+          git clone git@github.com:vmware/repository-service-tuf-cli.git rstuf-cli
+          cd rstuf-cli
+          git fetch
+          git pull
+          git checkout main          
+          cd ..
+          pip install rstuf-cli/
 
       - name: Install the RSTUF Command Line Interface (latest)
         if: ${{ inputs.cli_version == 'latest' }}
@@ -107,12 +111,13 @@ jobs:
         # run: |
         #   pip install "dynaconf[ini]" repository-service-tuf
         run: |
-          git submodule update --init repository-service-tuf-cli
-          git submodule foreach git pull origin main
-          cd repository-service-tuf-cli
-          git checkout $(git tag -l --sort=version:refname | tail -1 && cd ..)
-          pip install .
+          git clone git@github.com:vmware/repository-service-tuf-cli.git rstuf-cli
+          cd rstuf-cli
+          git fetch
+          git pull
+          git checkout $(git tag -l --sort=version:refname | tail -1)          
           cd ..
+          pip install rstuf-cli/        
 
       - name: Install the RSTUF Command Line Interface (vX.Y.Z)
         if: ${{ startsWith(inputs.cli_version, 'v') }}
@@ -121,12 +126,13 @@ jobs:
         # run: |
         #   pip install "dynaconf[ini]" repository-service-tuf==${{ inputs.cli_version }}
         run: |
-          git submodule update --init repository-service-tuf-cli
-          git submodule foreach git pull origin main
-          cd repository-service-tuf-cli
+          git clone git@github.com:vmware/repository-service-tuf-cli.git rstuf-cli
+          cd rstuf-cli
+          git fetch
+          git pull
           git checkout ${{ inputs.cli_version }}
-          pip install .
           cd ..
+          pip install rstuf-cli/        
 
       - name: Functional Tests (BDD)
         env:


### PR DESCRIPTION
It simplifies the GHA workflow to use the git clone instead of the submodules. It enables when used as ``workflow_call`` by other workflows and does not require the submodule.

The submodule is still required in the umbrella to handle the documentation builds.