### PR TITLE
fix: choose specific names for automated PRs

### DIFF
--- a/.github/workflows/update-python-deps.yml
+++ b/.github/workflows/update-python-deps.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "build: Update Python dependencies"
+          branch: "rstuf-bot/update-python-dependencies"
+          delete-branch: true
           title: "build: Update Python dependencies"
           body: >
             The following PR updates the Python dependencies and generates new pipfile and requirements file.

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: sync git submodules"
+          branch: "rstuf-bot/update-submodules"
+          delete-branch: true
           title: "chore: sync git submodules"
           body: >
             The following PR updates the submodule references in the umbrella repository for repository-service-tuf-api, repository-service-tuf-cli and repository-service-tuf-worker.


### PR DESCRIPTION
The following PR sets specific names for our automated PR process of updating dependencies and syncing submodules.

Fixes #109 

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>