### PR TITLE
build: update of update-submodules.yml

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -13,6 +13,7 @@ jobs:
   sync-submodules:
     name: "Sync submodules"
     runs-on: ubuntu-latest
+    needs: functional-tests
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - name: Sync git submodules

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: "0 8 * * *"
 jobs:
+  functional-tests:
+    uses: ./.github/workflows/functional.yml
+    with:
+      api_version: dev
+      worker_version: dev
+      cli_version: dev
   sync-submodules:
     name: "Sync submodules"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Go back to running the functional tests before updating the submodules. 
This is not optimal yet because it actually uses the `dev` tagged images and do not build the images on the go based on the actual references, but it will be enough for the time being to check whether it make sense to proceed with updating the submodules. 

The proposed solution is to build and tag images based on the content of the referenced submodules, then run the functional tests against those images.

Related to #150 