### PR TITLE
Remove the ANSI C1 scape sequence

### DIFF
--- a/tests/functional/bootstrap/test_bootstrap.py
+++ b/tests/functional/bootstrap/test_bootstrap.py
@@ -46,7 +46,7 @@ def the_administrator_uses_rstufcli_bootstrap(rstuf_cli):
 def the_admin_gets(bootstrap):
     _, output = bootstrap
 
-    assert "SUCCESS" or "System already has a Metadata." in output
+    assert "SUCCESS" in output or "System already has a Metadata." in output
     assert (
         "Bootstrap finished." in output
         or "System already has a Metadata." in output

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 from typing import List
 
@@ -13,11 +14,11 @@ def get_admin_pwd():
 @pytest.fixture
 def rstuf_cli():
     def _run_rstuf_cli(params: List):
-
+        ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
         result = subprocess.run(
             ["rstuf", "-c", "rstuf.ini"] + params.split(), capture_output=True
         )
 
-        return result.returncode, result.stdout.decode("utf-8")
+        return result.returncode, ansi_escape.sub('', result.stdout.decode("utf-8"))
 
     return _run_rstuf_cli

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -14,11 +14,13 @@ def get_admin_pwd():
 @pytest.fixture
 def rstuf_cli():
     def _run_rstuf_cli(params: List):
-        ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+        ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
         result = subprocess.run(
             ["rstuf", "-c", "rstuf.ini"] + params.split(), capture_output=True
         )
 
-        return result.returncode, ansi_escape.sub('', result.stdout.decode("utf-8"))
+        return result.returncode, ansi_escape.sub(
+            "", result.stdout.decode("utf-8")
+        )
 
     return _run_rstuf_cli


### PR DESCRIPTION
It prevents errors when the shell output from CLI shows some scapes and the assert will fail.

- Fix the assert with 'or'

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>