### PR TITLE
build: add the generated payload.json umbrella

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -153,7 +153,9 @@ jobs:
         run: rstuf -c rstuf.ini admin login -s http://localhost -u admin -p secret -e 1
 
       - name: Run the Offline Ceremony using RSTUF saving payload.json
-        run: 'pytest -vv rstuf-cli/tests/unit/cli/admin/test_ceremony.py::TestCeremonyGroupCLI::test_ceremony_start_default_values'
+        run: |
+          pytest -vv rstuf-cli/tests/unit/cli/admin/test_ceremony.py::TestCeremonyGroupCLI::test_ceremony_start_default_values
+          if [[ -d rstuf-umbrella ]]; then cp payload.json rstuf-umbrella/; fi
 
       - name: Run RSTUF Ceremony Bootstrap Upload
         run: 'rstuf -c rstuf.ini admin ceremony -b -u -f payload.json'


### PR DESCRIPTION
Add the generated payload.json to the rstuf-umbrella path it exists.

It is required by the BDD tests as the `make` command will run from another target folder.

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>