### PR TITLE
Add remove targets feature and functional tests + improvements

### DIFF
--- a/tests/features/targets/remove_targets.feature
+++ b/tests/features/targets/remove_targets.feature
@@ -1,0 +1,35 @@
+Feature: Adding targets in Repository Service for TUF (RSTUF)
+    As an admin,
+    Admin has deployed RSTUF,
+    Admin has run the ceremony and completed bootstrap successfully,
+    Admin has provided a token to the API requester
+
+    Scenario Outline: Removing targets using RSTUF api
+        Given the API requester has a token with scopes delete for targets and read for tasks
+        And the admin adds authorization Bearer 'access_token' in the 'headers'
+        And there are targets <paths> available for download using TUF client from the metadata repository
+        When the API requester deletes all of the following targets <paths>
+        Then the API requester should get status code '202' with 'task_id'
+        Then the API requester gets from endpoint 'GET /api/v1/task' status 'Task finished' within 90 seconds
+        Then all of the targets <paths> should not be available for download using TUF client from the metadata repository
+
+        Examples:
+            | paths                                                  |
+            | ["file1.tar.gz"]                                       |
+            | ["file1.tar.gz", "a/file2.tar.gz"]                     |
+            | ["file1.tar.gz", "a/file2.tar.gz", "a/b/file3.tar.gz"] |
+
+    Scenario Outline: Removing targets that does exist and ignoring the rest
+        Given the API requester has a token with scopes delete for targets and read for tasks
+        And the admin adds authorization Bearer 'access_token' in the 'headers'
+        And there are targets <paths> available for download using TUF client from the metadata repository
+        When the API requester tries to delete all of the following targets <paths> and <non_existing_paths>
+        Then the API requester should get status code '202' with 'task_id'
+        Then the API requester gets from endpoint 'GET /api/v1/task' status 'Task finished' within 90 seconds
+        Then the API requester should get a lists of deleted targets containing <paths> and of not found targets containing <non_existing_paths>
+        Then all of the targets <paths> should not be available for download using TUF client from the metadata repository
+
+        Examples:
+            | paths                              | non_existing_paths    |
+            | ["file1.tar.gz"]                   | ["foo"]               |
+            | ["file1.tar.gz", "a/file2.tar.gz"] | ["foo", "bar"]        |

--- a/tests/features/targets/remove_targets.feature
+++ b/tests/features/targets/remove_targets.feature
@@ -10,8 +10,8 @@ Feature: Adding targets in Repository Service for TUF (RSTUF)
         And there are targets <paths> available for download using TUF client from the metadata repository
         When the API requester deletes all of the following targets <paths>
         Then the API requester should get status code '202' with 'task_id'
-        Then the API requester gets from endpoint 'GET /api/v1/task' status 'Task finished' within 90 seconds
-        Then all of the targets <paths> should not be available for download using TUF client from the metadata repository
+        And the API requester gets from endpoint 'GET /api/v1/task' status 'Task finished' within 90 seconds
+        And all of the targets <paths> should not be available for download using TUF client from the metadata repository
 
         Examples:
             | paths                                                  |
@@ -25,11 +25,12 @@ Feature: Adding targets in Repository Service for TUF (RSTUF)
         And there are targets <paths> available for download using TUF client from the metadata repository
         When the API requester tries to delete all of the following targets <paths> and <non_existing_paths>
         Then the API requester should get status code '202' with 'task_id'
-        Then the API requester gets from endpoint 'GET /api/v1/task' status 'Task finished' within 90 seconds
-        Then the API requester should get a lists of deleted targets containing <paths> and of not found targets containing <non_existing_paths>
-        Then all of the targets <paths> should not be available for download using TUF client from the metadata repository
+        And the API requester gets from endpoint 'GET /api/v1/task' status 'Task finished' within 90 seconds
+        And the API requester should get a lists of deleted targets containing <paths> and of not found targets containing <non_existing_paths>
+        And all of the targets <paths> should not be available for download using TUF client from the metadata repository
 
         Examples:
             | paths                              | non_existing_paths    |
             | ["file1.tar.gz"]                   | ["foo"]               |
+            | []                                 | ["foo", "bar"]        |
             | ["file1.tar.gz", "a/file2.tar.gz"] | ["foo", "bar"]        |

--- a/tests/features/targets/remove_targets.feature
+++ b/tests/features/targets/remove_targets.feature
@@ -17,7 +17,7 @@ Feature: Adding targets in Repository Service for TUF (RSTUF)
             | paths                                                  |
             | ["file1.tar.gz"]                                       |
             | ["file1.tar.gz", "a/file2.tar.gz"]                     |
-            | ["file1.tar.gz", "a/file2.tar.gz", "a/b/file3.tar.gz"] |
+            | ["file1.tar.gz", "a/file2.tar.gz", "c/d/file3.tar.gz"] |
 
     Scenario Outline: Removing targets that does exist and ignoring the rest
         Given the API requester has a token with scopes delete for targets and read for tasks

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -65,7 +65,7 @@ def access_token(http_request, get_admin_pwd):
     data = {
         "username": "admin",
         "password": get_admin_pwd,
-        "scope": "write:token read:tasks write:targets",
+        "scope": "write:token read:tasks write:targets delete:targets",
         "expires": 1,
     }
     response = http_request(method="POST", url="/api/v1/token", data=data)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -104,7 +104,7 @@ def task_completed_within_threshold():
         task_submitted = dateutil.parser.parse(
             response_json["data"]["last_update"]
         )
-        rp_json = None
+        task_response_json = None
         while (
             datetime.utcnow() - task_submitted
         ).total_seconds() <= threshold:
@@ -114,10 +114,10 @@ def task_completed_within_threshold():
                 headers=headers,
             )
             assert response.status_code == 200, response.text
-            rp_json = response.json()
+            task_response_json = response.json()
             # "result" is missing when the task is still "PENDING"
             status = ""
-            result = rp_json["data"].get("result")
+            result = task_response_json["data"].get("result")
             if result is not None:
                 # "status" is missing when the task is in its earliest stage
                 status = result.get("status")
@@ -130,6 +130,6 @@ def task_completed_within_threshold():
                 f"Task should be completed in {threshold} seconds."
             )
 
-        return rp_json
+        return task_response_json
 
     return _run_task_completion_check

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -105,8 +105,8 @@ def task_completed_within_threshold():
             response_json["data"]["last_update"]
         )
         while (
-            (datetime.utcnow() - task_submitted).total_seconds()
-        ) <= threshold:
+            datetime.utcnow() - task_submitted
+        ).total_seconds() <= threshold:
             response = http_request(
                 method="GET",
                 url=f"/api/v1/task/?task_id={task_id}",
@@ -124,7 +124,7 @@ def task_completed_within_threshold():
             if status == "Task finished.":
                 break
 
-        if ((datetime.utcnow() - task_submitted).total_seconds()) > threshold:
+        if (datetime.utcnow() - task_submitted).total_seconds() > threshold:
             raise TimeoutError(
                 f"Task should be completed in {threshold} seconds."
             )

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -3,8 +3,10 @@ import re
 import shutil
 import subprocess
 import tempfile
+from datetime import datetime
 from typing import List
 
+import dateutil.parser
 import pytest
 import requests
 from tuf.ngclient import Updater, UpdaterConfig
@@ -90,3 +92,41 @@ def get_target_info():
         return updater.get_targetinfo(target_path)
 
     return _run_get_target_info
+
+
+@pytest.fixture
+def task_completed_within_threshold():
+    def _run_task_completion_check(
+        http_request, headers, response_json, threshold
+    ):
+        """Validates that a task has finished within a threshold of seconds."""
+        task_id = response_json["data"]["task_id"]
+        task_submitted = dateutil.parser.parse(
+            response_json["data"]["last_update"]
+        )
+        while (
+            (datetime.utcnow() - task_submitted).total_seconds()
+        ) <= threshold:
+            response = http_request(
+                method="GET",
+                url=f"/api/v1/task/?task_id={task_id}",
+                headers=headers,
+            )
+            assert response.status_code == 200, response.text
+            rp_json = response.json()
+            # "result" is missing when the task is still "PENDING"
+            status = ""
+            result = rp_json["data"].get("result")
+            if result is not None:
+                # "status" is missing when the task is in its earliest stage
+                status = result.get("status")
+
+            if status == "Task finished.":
+                break
+
+        if ((datetime.utcnow() - task_submitted).total_seconds()) > threshold:
+            raise TimeoutError(
+                f"Task should be completed in {threshold} seconds."
+            )
+
+    return _run_task_completion_check

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -104,6 +104,7 @@ def task_completed_within_threshold():
         task_submitted = dateutil.parser.parse(
             response_json["data"]["last_update"]
         )
+        rp_json = None
         while (
             datetime.utcnow() - task_submitted
         ).total_seconds() <= threshold:
@@ -128,5 +129,7 @@ def task_completed_within_threshold():
             raise TimeoutError(
                 f"Task should be completed in {threshold} seconds."
             )
+
+        return rp_json
 
     return _run_task_completion_check

--- a/tests/functional/targets/test_add_targets.py
+++ b/tests/functional/targets/test_add_targets.py
@@ -45,12 +45,6 @@ def the_admin_adds_authorization_token_in_the_headers(access_token):
 def the_api_requester_adds_a_new_target(
     http_request, headers, length, hashes, custom, path
 ):
-    if custom == "None":
-        custom = None
-
-    if path == "None":
-        path = None
-
     # remove quotes; example "['str', 'str']" -> to python list['str', 'str']
     hashes = ast.literal_eval(hashes)
     path = ast.literal_eval(path)
@@ -67,7 +61,7 @@ def the_api_requester_adds_a_new_target(
         ]
     }
 
-    if custom is not None:
+    if custom != "None":
         custom = ast.literal_eval(custom)
         payload["targets"][0]["info"].update({"custom": custom})
 
@@ -118,6 +112,7 @@ def the_api_requester_gets_task_status_task_finished_within_threshold(
 
     if ((datetime.utcnow() - task_submitted).total_seconds()) > THRESHOLD:
         raise TimeoutError(f"Task should be completed in {THRESHOLD} seconds.")
+
 
 
 @then(

--- a/tests/functional/targets/test_add_targets.py
+++ b/tests/functional/targets/test_add_targets.py
@@ -1,9 +1,7 @@
 """Adding targets in Repository Service for TUF (RSTUF) feature tests."""
 
 import ast
-from datetime import datetime
 
-import dateutil.parser
 from pytest_bdd import given, scenario, then, when
 from pytest_bdd.parsers import parse
 
@@ -84,35 +82,12 @@ def the_api_requester_gets_successful_message(response):
     "'Task finished' within 90 seconds"
 )
 def the_api_requester_gets_task_status_task_finished_within_threshold(
-    http_request, headers, response_json
+    http_request, headers, task_completed_within_threshold, response_json
 ):
-
-    THRESHOLD = 90
-    task_id = response_json["data"]["task_id"]
-    task_submitted = dateutil.parser.parse(
-        response_json["data"]["last_update"]
+    threshold = 90
+    task_completed_within_threshold(
+        http_request, headers, response_json, threshold
     )
-    while ((datetime.utcnow() - task_submitted).total_seconds()) <= THRESHOLD:
-        response = http_request(
-            method="GET",
-            url=f"/api/v1/task/?task_id={task_id}",
-            headers=headers,
-        )
-        assert response.status_code == 200, response.text
-        rp_json = response.json()
-        # "result" is missing when the task is still "PENDING"
-        status = ""
-        result = rp_json["data"].get("result")
-        if result is not None:
-            # "status" is missing when the task is in its earliest stage
-            status = result.get("status")
-
-        if status == "Task finished.":
-            break
-
-    if ((datetime.utcnow() - task_submitted).total_seconds()) > THRESHOLD:
-        raise TimeoutError(f"Task should be completed in {THRESHOLD} seconds.")
-
 
 
 @then(

--- a/tests/functional/targets/test_remove_targets.py
+++ b/tests/functional/targets/test_remove_targets.py
@@ -102,13 +102,14 @@ def the_api_requester_gets_successful_message(response):
 
 @then(
     "the API requester gets from endpoint 'GET /api/v1/task' status "
-    "'Task finished' within 90 seconds"
+    "'Task finished' within 90 seconds",
+    target_fixture="api_response",
 )
 def the_api_requester_gets_task_status_finished_within_threshold(
     http_request, headers, task_completed_within_threshold, response_json
 ):
     threshold = 90
-    task_completed_within_threshold(
+    return task_completed_within_threshold(
         http_request, headers, response_json, threshold
     )
 
@@ -155,46 +156,19 @@ def the_api_requester_tries_to_delete_all_targets(
 
 
 @then(
-    "the API requester gets from endpoint 'GET /api/v1/task' status "
-    "'Task finished' within 90 seconds",
-    target_fixture="targets_dict",
-)
-def the_api_requester_gets_task_status_finished_and_get_task_details(
-    http_request, headers, task_completed_within_threshold, response_json
-):
-    threshold = 90
-    task_completed_within_threshold(
-        http_request, headers, response_json, threshold
-    )
-
-    task_id = response_json["data"]["task_id"]
-    response = http_request(
-        method="GET",
-        url=f"/api/v1/task/?task_id={task_id}",
-        headers=headers,
-    )
-    rp_json = response.json()
-
-    return {
-        "deleted": rp_json["data"]["result"]["details"]["deleted_targets"],
-        "not_found": rp_json["data"]["result"]["details"]["not_found_targets"],
-    }
-
-
-@then(
     parse(
         "the API requester should get a lists of deleted targets containing "
         "{paths} and of not found targets containing {non_existing_paths}"
     )
 )
 def the_api_requester_gets_deleted_and_not_found_lists(
-    paths,
-    non_existing_paths,
-    targets_dict,
+    paths, non_existing_paths, api_response
 ):
+    deleted = api_response["data"]["result"]["details"]["deleted_targets"]
+    not_found = api_response["data"]["result"]["details"]["not_found_targets"]
     # remove quotes; example "[str, str]" -> [str, str]
     paths = ast.literal_eval(paths)
     non_existing_paths = ast.literal_eval(non_existing_paths)
     # Sort lists, so that order doesn't lead to unwanted differences
-    assert sorted(paths) == sorted(targets_dict["deleted"])
-    assert sorted(non_existing_paths) == sorted(targets_dict["not_found"])
+    assert sorted(paths) == sorted(deleted)
+    assert sorted(non_existing_paths) == sorted(not_found)

--- a/tests/functional/targets/test_remove_targets.py
+++ b/tests/functional/targets/test_remove_targets.py
@@ -1,0 +1,200 @@
+"""Adding targets in Repository Service for TUF (RSTUF) feature tests."""
+
+import ast
+from typing import Any, Dict
+
+from pytest_bdd import given, scenario, then, when
+from pytest_bdd.parsers import parse
+
+
+@scenario(
+    "../../features/targets/remove_targets.feature",
+    "Removing targets using RSTUF api",
+)
+def test_removing_a_target_using_rstuf_api():
+    """Removing targets using RSTUF api."""
+
+
+@given(
+    "the API requester has a token with scopes delete for targets and "
+    "read for tasks",
+    target_fixture="access_token",
+)
+def the_api_requester_has_a_token_with_scope_specific_scope(access_token):
+    return access_token
+
+
+@given(
+    "the admin adds authorization Bearer 'access_token' in the 'headers'",
+    target_fixture="headers",
+)
+def the_admin_adds_authorization_token_in_the_headers(access_token):
+    header_token = f"Bearer {access_token}"
+    headers = {"Authorization": header_token}
+    return headers
+
+
+@given(
+    parse(
+        "there are targets {paths} available for download using TUF client "
+        "from the metadata repository"
+    )
+)
+def there_are_targets_available_for_download(
+    http_request,
+    headers,
+    get_target_info,
+    task_completed_within_threshold,
+    paths,
+):
+    payload: Dict[str, list[Dict[str, Any]]] = {"targets": []}
+    # remove quotes; example "[str, str]" -> [str, str]
+    paths = ast.literal_eval(paths)
+    for path in paths:
+        payload["targets"].append(
+            {
+                "info": {
+                    "length": 630,
+                    "hashes": {
+                        "blake2b-256": "69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9"  # noqa: E501
+                    },
+                    "custom": {"key": "value"},
+                },
+                "path": path,
+            }
+        )
+
+    response = http_request(
+        method="POST", url="/api/v1/targets", headers=headers, json=payload
+    )
+    assert response.status_code == 202, response.text
+    threshold = 90
+    task_completed_within_threshold(
+        http_request, headers, response.json(), threshold
+    )
+    # Make sure all of the targets can be downloaded
+    for path in paths:
+        target_info = get_target_info(path)
+        assert target_info is not None
+
+
+@when(
+    parse("the API requester deletes all of the following targets {paths}"),
+    target_fixture="response",
+)
+def the_api_requester_deletes_targets(http_request, headers, paths):
+    # remove quotes; example "[str, str]" -> [str, str]
+    paths = ast.literal_eval(paths)
+    payload = {"targets": paths}
+    return http_request(
+        method="DELETE", url="/api/v1/targets", headers=headers, json=payload
+    )
+
+
+@then(
+    "the API requester should get status code '202' with 'task_id'",
+    target_fixture="response_json",
+)
+def the_api_requester_gets_successful_message(response):
+    assert response.status_code == 202, response.text
+    return response.json()
+
+
+@then(
+    "the API requester gets from endpoint 'GET /api/v1/task' status "
+    "'Task finished' within 90 seconds"
+)
+def the_api_requester_gets_task_status_finished_within_threshold(
+    http_request, headers, task_completed_within_threshold, response_json
+):
+    threshold = 90
+    task_completed_within_threshold(
+        http_request, headers, response_json, threshold
+    )
+
+
+@then(
+    parse(
+        "all of the targets {paths} should not be available for download "
+        "using TUF client from the metadata repository"
+    )
+)
+def the_targets_are_no_longer_available_for_download(get_target_info, paths):
+    # remove quotes; example "[str, str]" -> [str, str]
+    paths = ast.literal_eval(paths)
+    for path in paths:
+        target_info = get_target_info(path)
+        assert target_info is None
+
+
+@scenario(
+    "../../features/targets/remove_targets.feature",
+    "Removing targets that does exist and ignoring the rest",
+)
+def test_removing_targets_that_does_exist_and_ignoring_the_rest():
+    """Removing targets that does exist and ignoring the rest."""
+
+
+@when(
+    parse(
+        "the API requester tries to delete all of the following targets "
+        "{paths} and {non_existing_paths}"
+    ),
+    target_fixture="response",
+)
+def the_api_requester_tries_to_delete_all_targets(
+    http_request, headers, paths, non_existing_paths
+):
+    # remove quotes; example "[str, str]" -> [str, str]
+    paths = ast.literal_eval(paths)
+    non_existing_paths = ast.literal_eval(non_existing_paths)
+    payload = {"targets": paths + non_existing_paths}
+    return http_request(
+        method="DELETE", url="/api/v1/targets", headers=headers, json=payload
+    )
+
+
+@then(
+    "the API requester gets from endpoint 'GET /api/v1/task' status "
+    "'Task finished' within 90 seconds",
+    target_fixture="targets_dict",
+)
+def the_api_requester_gets_task_status_finished_and_get_task_details(
+    http_request, headers, task_completed_within_threshold, response_json
+):
+    threshold = 90
+    task_completed_within_threshold(
+        http_request, headers, response_json, threshold
+    )
+
+    task_id = response_json["data"]["task_id"]
+    response = http_request(
+        method="GET",
+        url=f"/api/v1/task/?task_id={task_id}",
+        headers=headers,
+    )
+    rp_json = response.json()
+
+    return {
+        "deleted": rp_json["data"]["result"]["details"]["deleted_targets"],
+        "not_found": rp_json["data"]["result"]["details"]["not_found_targets"],
+    }
+
+
+@then(
+    parse(
+        "the API requester should get a lists of deleted targets containing "
+        "{paths} and of not found targets containing {non_existing_paths}"
+    )
+)
+def the_api_requester_gets_deleted_and_not_found_lists(
+    paths,
+    non_existing_paths,
+    targets_dict,
+):
+    # remove quotes; example "[str, str]" -> [str, str]
+    paths = ast.literal_eval(paths)
+    non_existing_paths = ast.literal_eval(non_existing_paths)
+    # Sort lists, so that order doesn't lead to unwanted differences
+    assert sorted(paths) == sorted(targets_dict["deleted"])
+    assert sorted(non_existing_paths) == sorted(targets_dict["not_found"])


### PR DESCRIPTION
The main changes of this pr are:
- added remove targets feature file with scenarios description
- added functional tests for the remove targets feature file
- added improvements in contests that simplified test_add_targets.py functional tests as well
- simplified the test_add_targets.py functional tests

Note: In the second scenario `Removing targets that do exist and ignoring the rest` in test_remove_targets.py I am reusing fixtures (steps) defined from the first scenario.
I reused some of the `given` and `then` steps.