### PR TITLE
Add OpenSSF Best Practices badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,12 @@
 Repository Service for TUF (RSTUF)
 ==================================
 
+|OpenSSF Best Practices|
+
+.. |OpenSSF Best Practices| image:: https://bestpractices.coreinfrastructure.org/projects/6587/badge
+  :target: https://bestpractices.coreinfrastructure.org/projects/6587
+
+
 .. note::
 
     Repository Service for TUF is a *work in progress*.


### PR DESCRIPTION
Add the OpenSSF Best Practices badge to RSTUF umbrella README.rst (it adds also to RSTUF documentation)

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>