### PR TITLE
RSTUF umbrella repository list all maintainers

### DIFF
--- a/MAINTAINERS.rst
+++ b/MAINTAINERS.rst
@@ -21,3 +21,17 @@ Radoslav Dimitrov
 Email: dimitrovr@vmware.com
 
 GitHub username: @rdimitrov
+
+Lukas Pühringer
+-------------------------
+
+Email: lukas.puehringer@nyu.edu
+
+GitHub username: @lukpueh
+
+Konstantinos Papadopoulos
+-------------------------
+
+Email: konpap1996@yahoo.com
+
+GitHub username: @KAUTH


### PR DESCRIPTION
Given that each component maintainer contributes to the overall project maintenance,
this PR adds all component maintainers in the umbrella repository `MAINTAINERS.rst`.